### PR TITLE
[Feature] Moving selected_tests inside the TestRunExecution

### DIFF
--- a/alembic/versions/8a36d0df90b0_adding_new_column_selected_tests.py
+++ b/alembic/versions/8a36d0df90b0_adding_new_column_selected_tests.py
@@ -1,0 +1,93 @@
+"""Adding new column selected_tests
+
+Revision ID: 8a36d0df90b0
+Revises: 3189c039e59b
+Create Date: 2023-12-04 20:15:28.319836
+
+"""
+import json
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "8a36d0df90b0"
+down_revision = "3189c039e59b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "testrunexecution", sa.Column("selected_tests", sa.JSON(), nullable=True)
+    )
+
+    t_testrunexecution = sa.Table(
+        "testrunexecution",
+        sa.MetaData(),
+        sa.Column("id", sa.String(32)),
+        sa.Column("selected_tests", sa.Unicode(length=1000)),
+    )
+    t_testsuiteexecution = sa.Table(
+        "testsuiteexecution",
+        sa.MetaData(),
+        sa.Column("id", sa.String(32)),
+        sa.Column("public_id", sa.Unicode(length=100)),
+        sa.Column("collection_id", sa.Unicode(length=100)),
+        sa.Column("test_run_execution_id", sa.Unicode(length=100)),
+    )
+    t_testcaseexecution = sa.Table(
+        "testcaseexecution",
+        sa.MetaData(),
+        sa.Column("public_id", sa.Unicode(length=100)),
+        sa.Column("test_suite_execution_id", sa.Unicode(length=100)),
+    )
+    connection = op.get_bind()
+    run_ids = [
+        r[0] for r in connection.execute(sa.select(t_testrunexecution.c.id)).all()
+    ]
+    for run_id in run_ids:
+        selected_tests = {"collections": []}
+        collections = [
+            c[0]
+            for c in connection.execute(
+                sa.select(t_testsuiteexecution.c.collection_id)
+                .where(t_testsuiteexecution.c.test_run_execution_id == run_id)
+                .distinct()
+            ).all()
+        ]
+        for collection in collections:
+            selected_tests["collections"].append(
+                {"public_id": collection, "test_suites": []}
+            )
+            suites = connection.execute(
+                sa.select(
+                    t_testsuiteexecution.c.id, t_testsuiteexecution.c.public_id
+                ).where(
+                    (t_testsuiteexecution.c.test_run_execution_id == run_id)
+                    & (t_testsuiteexecution.c.collection_id == collection)
+                )
+            ).all()
+            for suite in suites:
+                cases = [
+                    {"public_id": c[0], "iterations": 1}
+                    for c in connection.execute(
+                        sa.select(t_testcaseexecution.c.public_id).where(
+                            t_testcaseexecution.c.test_suite_execution_id == suite[0]
+                        )
+                    ).all()
+                ]
+                selected_tests["collections"][-1]["test_suites"].append(
+                    {"public_id": suite[1], "test_cases": cases}
+                )
+        connection.execute(
+            t_testrunexecution.update()
+            .where(t_testrunexecution.c.id == run_id)
+            .values(selected_tests=json.dumps(selected_tests))
+        )
+    op.alter_column("testrunexecution", "selected_tests", nullable=False)
+
+
+def downgrade():
+    op.drop_column("testrunexecution", "selected_tests")

--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -31,11 +31,7 @@ from app.models.test_run_execution import TestRunExecution
 from app.test_engine import TEST_ENGINE_ABORTING_TESTING_MESSAGE
 from app.test_engine.test_runner import AbortError, LoadingError, TestRunner
 from app.test_engine.test_script_manager import TestNotFound
-from app.utils import (
-    formated_datetime_now_str,
-    remove_title_date,
-    selected_tests_from_execution,
-)
+from app.utils import formated_datetime_now_str, remove_title_date
 from app.version import version_information
 
 router = APIRouter()
@@ -77,13 +73,12 @@ def create_test_run_execution(
     *,
     db: Session = Depends(get_db),
     test_run_execution_in: schemas.TestRunExecutionCreate,
-    selected_tests: schemas.SelectedTests,
 ) -> TestRunExecution:
     """
     Create new test run execution.
     """
-    test_run_execution = crud.test_run_execution.create_with_selected_tests(
-        db=db, obj_in=test_run_execution_in, selected_tests=selected_tests
+    test_run_execution = crud.test_run_execution.create(
+        db=db, obj_in=test_run_execution_in
     )
     return test_run_execution
 
@@ -254,16 +249,14 @@ def repeat_test_run_execution(
     date_now = formated_datetime_now_str()
     title += date_now
 
-    test_run_execution_in = schemas.TestRunExecutionCreate(title=title)
+    test_run_execution_in = schemas.TestRunExecutionCreate(
+        title=title, selected_tests=execution_to_repeat.selected_tests
+    )
     test_run_execution_in.description = execution_to_repeat.description
     test_run_execution_in.project_id = execution_to_repeat.project_id
     test_run_execution_in.operator_id = execution_to_repeat.operator_id
 
-    return crud.test_run_execution.create_with_selected_tests(
-        db=db,
-        obj_in=test_run_execution_in,
-        selected_tests=selected_tests_from_execution(execution_to_repeat),
-    )
+    return crud.test_run_execution.create(db=db, obj_in=test_run_execution_in)
 
 
 @router.delete("/{id}", response_model=schemas.TestRunExecutionInDBBase)

--- a/app/crud/crud_test_run_execution.py
+++ b/app/crud/crud_test_run_execution.py
@@ -175,22 +175,9 @@ class CRUDTestRunExecution(
 
         test_run_execution = super().create(db=db, obj_in=obj_in)
 
-        db.commit()
-        db.refresh(test_run_execution)
-        return test_run_execution
-
-    def create_with_selected_tests(
-        self,
-        db: Session,
-        obj_in: TestRunExecutionCreate,
-        selected_tests: SelectedTests,
-        **kwargs: Optional[dict],
-    ) -> TestRunExecution:
-        test_run_execution = self.create(db, obj_in=obj_in, **kwargs)
-
         test_suites = (
             test_script_manager.pending_test_suite_executions_for_selected_tests(
-                selected_tests
+                SelectedTests(**obj_in.selected_tests)
             )
         )
 

--- a/app/models/test_run_execution.py
+++ b/app/models/test_run_execution.py
@@ -16,7 +16,7 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import Enum, ForeignKey, func, select
+from sqlalchemy import JSON, Enum, ForeignKey, func, select
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.mutable import MutableList
 from sqlalchemy.ext.orderinglist import ordering_list
@@ -76,6 +76,8 @@ class TestRunExecution(Base):
     project: Mapped["Project"] = relationship(
         "Project", back_populates="test_run_executions"
     )
+
+    selected_tests: Mapped[dict] = mapped_column(JSON, nullable=False)
 
     def append_to_log(self, log_record: "TestRunLogEntry") -> None:
         self.log.append(log_record)

--- a/app/schemas/test_run_execution.py
+++ b/app/schemas/test_run_execution.py
@@ -49,6 +49,7 @@ class TestRunExecutionBaseWithRelationships(TestRunExecutionBase):
 class TestRunExecutionCreate(TestRunExecutionBaseWithRelationships):
     # TODO(#124): Require project ID when UI supports project management.
     operator_id: Optional[int]
+    selected_tests: dict
 
 
 # Properties shared by models stored in DB

--- a/app/tests/api/api_v1/test_test_run_executions.py
+++ b/app/tests/api/api_v1/test_test_run_executions.py
@@ -39,7 +39,7 @@ from app.test_engine import (
     TEST_RUN_ALREADY_EXECUTED_MESSAGE,
 )
 from app.test_engine.test_runner import TestRunner, TestRunnerState
-from app.tests.test_engine.test_runner import load_test_run_for_test_cases
+from app.tests.test_engine.test_runner import load_test_run_for_selected_tests
 from app.tests.utils.operator import create_random_operator
 from app.tests.utils.project import create_random_project
 from app.tests.utils.test_run_execution import (
@@ -84,10 +84,8 @@ def test_create_test_run_execution_with_selected_tests_succeeds(
         ]
     }
     json_data = {
-        "test_run_execution_in": {
-            "title": title,
-            "description": description,
-        },
+        "title": title,
+        "description": description,
         "selected_tests": selected_tests,
     }
     response = client.post(
@@ -113,13 +111,25 @@ def test_create_test_run_execution_with_selected_tests_and_operator_succeeds(
     """
     title = "Foo"
     operator = create_random_operator(db)
+    selected_tests = {
+        "collections": [
+            {
+                "public_id": "sample_tests",
+                "test_suites": [
+                    {
+                        "public_id": "SampleTestSuite1",
+                        "test_cases": [
+                            {"public_id": "TCSS1001", "iterations": 1},
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
     json_data = {
-        "test_run_execution_in": {"title": title, "operator_id": operator.id},
-        "selected_tests": {
-            "sample_tests": {
-                "SampleTestSuite1": {"TCSS1001": 1},
-            },
-        },
+        "title": title,
+        "operator_id": operator.id,
+        "selected_tests": selected_tests,
     }
     response = client.post(
         f"{settings.API_V1_STR}/test_run_executions/",
@@ -149,17 +159,26 @@ def test_create_test_run_execution_with_selected_tests_project_operator_succeeds
     title = "TestRunExecutionFoo"
     project = create_random_project(db)
     operator = create_random_operator(db)
+    selected_tests = {
+        "collections": [
+            {
+                "public_id": "sample_tests",
+                "test_suites": [
+                    {
+                        "public_id": "SampleTestSuite1",
+                        "test_cases": [
+                            {"public_id": "TCSS1001", "iterations": 1},
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
     json_data = {
-        "test_run_execution_in": {
-            "title": title,
-            "operator_id": operator.id,
-            "project_id": project.id,
-        },
-        "selected_tests": {
-            "sample_tests": {
-                "SampleTestSuite1": {"TCSS1001": 1},
-            },
-        },
+        "title": title,
+        "operator_id": operator.id,
+        "project_id": project.id,
+        "selected_tests": selected_tests,
     }
     response = client.post(
         f"{settings.API_V1_STR}/test_run_executions/",
@@ -218,10 +237,8 @@ def test_create_test_run_execution_with_selected_tests_with_two_suites_succeeds(
         ]
     }
     json_data = {
-        "test_run_execution_in": {
-            "title": title,
-            "description": description,
-        },
+        "title": title,
+        "description": description,
         "selected_tests": selected_tests,
     }
     response = client.post(
@@ -256,10 +273,8 @@ def test_create_test_run_execution_without_selected_tests_fails(
     title = "TestRunExecutionFoo"
     description = random_lower_string()
     json_data = {
-        "test_run_execution_in": {
-            "title": title,
-            "description": description,
-        }
+        "title": title,
+        "description": description,
     }
     response = client.post(
         f"{settings.API_V1_STR}/test_run_executions/",
@@ -859,9 +874,7 @@ async def test_test_runner_status_running(
         ]
     }
 
-    test_runner = load_test_run_for_test_cases(
-        db=db, test_cases=SelectedTests(**selected_tests)
-    )
+    test_runner = load_test_run_for_selected_tests(db=db, selected_tests=selected_tests)
 
     # Start running tests (async)
     run_task = asyncio.create_task(test_runner.run())

--- a/app/tests/crud/test_test_run_execution.py
+++ b/app/tests/crud/test_test_run_execution.py
@@ -28,7 +28,6 @@ from sqlalchemy.orm import Session
 from app import crud, models, schemas
 from app.crud.crud_test_run_execution import ImportError
 from app.models.test_enums import TestStateEnum
-from app.schemas import SelectedTests
 from app.schemas.test_run_execution import (
     TestRunExecutionCreate,
     TestRunExecutionWithStats,

--- a/app/tests/crud/test_test_run_execution.py
+++ b/app/tests/crud/test_test_run_execution.py
@@ -51,11 +51,14 @@ def test_get_test_run_execution(db: Session) -> None:
     # Create build new test_run_execution object
     title = random_lower_string()
     description = random_lower_string()
+    selected_tests = {"collections": []}
     test_run_execution_dict = random_test_run_execution_dict(
         title=title, description=description
     )
 
-    test_run_execution_in = TestRunExecutionCreate(**test_run_execution_dict)
+    test_run_execution_in = TestRunExecutionCreate(
+        **test_run_execution_dict, selected_tests=selected_tests
+    )
 
     # Save create test_run_execution in DB
     test_run_execution = crud.test_run_execution.create(
@@ -72,6 +75,7 @@ def test_get_test_run_execution(db: Session) -> None:
     assert test_run_execution.id == stored_test_run_execution.id
     assert test_run_execution.title == stored_test_run_execution.title
     assert test_run_execution.description == stored_test_run_execution.description
+    assert test_run_execution.selected_tests == selected_tests
 
 
 def test_test_run_archive(db: Session) -> None:
@@ -130,9 +134,12 @@ def test_test_run_unarchive_with_description(db: Session) -> None:
 def test_delete_test_run_execution(db: Session) -> None:
     # Create build new test_run_execution object
     title = random_lower_string()
+    selected_tests = {"collections": []}
     test_run_execution_dict = random_test_run_execution_dict(title=title)
 
-    test_run_execution_in = TestRunExecutionCreate(**test_run_execution_dict)
+    test_run_execution_in = TestRunExecutionCreate(
+        **test_run_execution_dict, selected_tests=selected_tests
+    )
 
     # Save create test_run_execution in DB
     test_run_execution = crud.test_run_execution.create(
@@ -148,6 +155,7 @@ def test_delete_test_run_execution(db: Session) -> None:
     assert test_run_execution_deleted is not None
     assert test_run_execution.id == test_run_execution_deleted.id
     assert test_run_execution.title == test_run_execution_deleted.title
+    assert test_run_execution.selected_tests == selected_tests
 
     # load stored test_run_execution from DB
     test_run_execution_none = crud.test_run_execution.get(
@@ -161,9 +169,7 @@ def test_delete_test_run_execution_with_a_test_suite(db: Session) -> None:
     # Create build new test_run_execution object
     title = random_lower_string()
     test_run_execution_dict = random_test_run_execution_dict(title=title)
-
-    test_run_execution_in = TestRunExecutionCreate(**test_run_execution_dict)
-    selected_tests = {
+    test_run_execution_dict["selected_tests"] = {
         "collections": [
             {
                 "public_id": "sample_tests",
@@ -177,11 +183,11 @@ def test_delete_test_run_execution_with_a_test_suite(db: Session) -> None:
         ]
     }
 
+    test_run_execution_in = TestRunExecutionCreate(**test_run_execution_dict)
+
     # Save create test_run_execution in DB
-    test_run_execution = crud.test_run_execution.create_with_selected_tests(
-        db=db,
-        obj_in=test_run_execution_in,
-        selected_tests=SelectedTests(**selected_tests),
+    test_run_execution = crud.test_run_execution.create(
+        db=db, obj_in=test_run_execution_in
     )
     assert len(test_run_execution.test_suite_executions) == 1
     suite = test_run_execution.test_suite_executions[0]
@@ -314,12 +320,12 @@ def test_create_test_run_execution_from_selected_tests(db: Session) -> None:
 
     # Prepare data for test_run_execution
     test_run_execution_title = "Test Execution title"
-    test_run_execution_data = TestRunExecutionCreate(title=test_run_execution_title)
+    test_run_execution_data = TestRunExecutionCreate(
+        title=test_run_execution_title, selected_tests=selected_tests
+    )
 
-    test_run_execution = crud.test_run_execution.create_with_selected_tests(
-        db=db,
-        obj_in=test_run_execution_data,
-        selected_tests=SelectedTests(**selected_tests),
+    test_run_execution = crud.test_run_execution.create(
+        db=db, obj_in=test_run_execution_data
     )
 
     # Assert direct properties

--- a/app/tests/test_engine/test_runner_abort_testing.py
+++ b/app/tests/test_engine/test_runner_abort_testing.py
@@ -20,12 +20,11 @@ import pytest
 from sqlalchemy.orm import Session
 
 from app.models.test_enums import TestStateEnum
-from app.schemas import SelectedTests
 from app.test_engine.test_runner import TestRunner
 from app.tests.utils.test_runner import (
     get_test_case_for_public_id,
     get_test_suite_for_public_id,
-    load_test_run_for_test_cases,
+    load_test_run_for_selected_tests,
 )
 from test_collections.tool_unit_tests.test_suite_expected import TestSuiteExpected
 from test_collections.tool_unit_tests.test_suite_expected.tctr_expected_pass import (
@@ -230,9 +229,7 @@ def __load_abort_tests(db: Session) -> Tuple[TestSuiteNeverEnding, TCNeverEnding
         ]
     }
 
-    test_runner = load_test_run_for_test_cases(
-        db=db, test_cases=SelectedTests(**selected_tests)
-    )
+    test_runner = load_test_run_for_selected_tests(db=db, selected_tests=selected_tests)
     run = test_runner.test_run
     assert run is not None
 
@@ -275,9 +272,7 @@ def __load_abort_tests_2_suites(
             }
         ]
     }
-    test_runner = load_test_run_for_test_cases(
-        db=db, test_cases=SelectedTests(**selected_tests)
-    )
+    test_runner = load_test_run_for_selected_tests(db=db, selected_tests=selected_tests)
     run = test_runner.test_run
     assert run is not None
 
@@ -327,9 +322,7 @@ def __load_abort_tests_2_tests_1_suite(
             }
         ]
     }
-    test_runner = load_test_run_for_test_cases(
-        db=db, test_cases=SelectedTests(**selected_tests)
-    )
+    test_runner = load_test_run_for_selected_tests(db=db, selected_tests=selected_tests)
     run = test_runner.test_run
     assert run is not None
 

--- a/app/tests/test_engine/test_runner_exceptions.py
+++ b/app/tests/test_engine/test_runner_exceptions.py
@@ -19,13 +19,12 @@ import pytest
 from sqlalchemy.orm import Session
 
 from app.models.test_enums import TestStateEnum
-from app.schemas import SelectedTests
 from app.test_engine.models import TestCase, TestSuite
 from app.tests.utils.test_runner import (
     get_test_case_for_public_id,
     get_test_suite_for_public_id,
     load_and_run_tool_unit_tests,
-    load_test_run_for_test_cases,
+    load_test_run_for_selected_tests,
 )
 from test_collections.tool_unit_tests.test_suite_exceptions import TestSuiteExceptions
 from test_collections.tool_unit_tests.test_suite_exceptions.tc_exception import (
@@ -485,9 +484,7 @@ async def test_exception_1st_test_suite_error_2nd_pass(
         ]
     }
 
-    test_runner = load_test_run_for_test_cases(
-        db=db, test_cases=SelectedTests(**selected_tests)
-    )
+    test_runner = load_test_run_for_selected_tests(db=db, selected_tests=selected_tests)
     # Save test_run reference to inspect models after completion
     test_run = test_runner.test_run
     assert test_run is not None

--- a/app/tests/utils/test_run_execution.py
+++ b/app/tests/utils/test_run_execution.py
@@ -22,7 +22,6 @@ from sqlalchemy.orm import Session
 from app import crud, models
 from app.models import TestRunExecution
 from app.models.test_enums import TestStateEnum
-from app.schemas import SelectedTests
 from app.schemas.test_run_execution import TestRunExecutionCreate
 from app.tests.utils.project import create_random_project
 
@@ -80,7 +79,7 @@ def create_random_test_run_execution_archived(
 
 
 def create_random_test_run_execution(
-    db: Session, selected_tests: SelectedTests = SelectedTests(), **kwargs: Any
+    db: Session, selected_tests: dict = {}, **kwargs: Any
 ) -> models.TestRunExecution:
     test_run_execution_dict = random_test_run_execution_dict(**kwargs)
 
@@ -88,12 +87,9 @@ def create_random_test_run_execution(
         project = create_random_project(db)
         test_run_execution_dict["project_id"] = project.id
 
+    test_run_execution_dict["selected_tests"] = selected_tests
     test_run_execution_in = TestRunExecutionCreate(**test_run_execution_dict)
-    return crud.test_run_execution.create_with_selected_tests(
-        db=db,
-        obj_in=test_run_execution_in,
-        selected_tests=selected_tests,
-    )
+    return crud.test_run_execution.create(db=db, obj_in=test_run_execution_in)
 
 
 def create_random_test_run_execution_with_test_case_states(
@@ -120,7 +116,7 @@ def create_random_test_run_execution_with_test_case_states(
     }
 
     test_run_execution = create_random_test_run_execution(
-        db=db, selected_tests=SelectedTests(**selected_tests)
+        db=db, selected_tests=selected_tests
     )
 
     test_suite_execution = test_run_execution.test_suite_executions[0]
@@ -140,7 +136,7 @@ def create_random_test_run_execution_with_test_case_states(
 def create_test_run_execution_with_some_test_cases(
     db: Session, **kwargs: Any
 ) -> TestRunExecution:
-    selected_tests_dict = {
+    selected_tests = {
         "collections": [
             {
                 "public_id": "sample_tests",
@@ -157,7 +153,6 @@ def create_test_run_execution_with_some_test_cases(
             }
         ]
     }
-    selected_tests = SelectedTests(**selected_tests_dict)
     return create_random_test_run_execution(
         db=db, selected_tests=selected_tests, **kwargs
     )

--- a/app/tests/utils/test_runner.py
+++ b/app/tests/utils/test_runner.py
@@ -17,7 +17,6 @@ from typing import Optional, Tuple, Type
 
 from sqlalchemy.orm import Session
 
-from app.schemas import SelectedTests
 from app.schemas.test_runner_status import TestRunnerState
 from app.test_engine.models import TestCase, TestRun, TestSuite
 from app.test_engine.test_runner import TestRunner
@@ -50,9 +49,9 @@ def get_test_suite_for_public_id(
     )
 
 
-def load_test_run_for_test_cases(db: Session, test_cases: SelectedTests) -> TestRunner:
+def load_test_run_for_selected_tests(db: Session, selected_tests: dict) -> TestRunner:
     test_run_execution = create_random_test_run_execution(
-        db=db, selected_tests=test_cases
+        db=db, selected_tests=selected_tests
     )
     # Get TestRunner (singleton)
     test_runner = TestRunner()
@@ -88,9 +87,7 @@ async def load_and_run_tool_unit_tests(
         ]
     }
 
-    runner = load_test_run_for_test_cases(
-        db=db, test_cases=SelectedTests(**selected_tests)
-    )
+    runner = load_test_run_for_selected_tests(db=db, selected_tests=selected_tests)
     run = runner.test_run
     assert run is not None
 


### PR DESCRIPTION
Moving selected_tests API parameter to inside the Test Run Execution model, schema and CRUD files.
That way we simplify removing one parameter from the creation API.

The following changes were provided:

- A new DB revision file was manually created so the new column `selected_test`, added into the `TestRunExecution` model, is filled with the information needed (gathered from tables inside the DB). This new column is mandatory as we'll always use this dictionary to create new Test Runs.
- The `create_test_run_execution()` API method had its `selected_test` parameter moved inside the `test_run_execution_in` object, as a dictionary blob.
- The CRUD file was updated to use only one create method once again.
- A dictionary was added to the schema for the selected_tests data.
- The model file maps the dictionary blob to a JSON type in DB.
- Related changes on unit tests and utils files.


